### PR TITLE
Added custom OperationIdFilter to apply the custom swagger definition…

### DIFF
--- a/Badgernet.Umbraco.MediaTools/Configurations/ConfigureSwaggerGenOptions.cs
+++ b/Badgernet.Umbraco.MediaTools/Configurations/ConfigureSwaggerGenOptions.cs
@@ -6,9 +6,9 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace Badgernet.Umbraco.MediaTools.Configurations;
 
 internal class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
-
 {
-    public void Configure(SwaggerGenOptions options){
+    public void Configure(SwaggerGenOptions options)
+    {
         options.SwaggerDoc(
             "mediatools",
             new OpenApiInfo
@@ -18,12 +18,8 @@ internal class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
                 Description = "Automatic media resizing and converting"
             });
 
-        
-
-        // sets the operation Ids to be the same as the action
-        // so it loses all the v1... bits to the names.
-        options.CustomOperationIds(e => $"{e.ActionDescriptor.RouteValues["action"]}");
+        // Add our scoped operation-id logic:
+        options.OperationFilter<MediaToolsOperationIdFilter>();
     }
-
 }
 

--- a/Badgernet.Umbraco.MediaTools/Configurations/MediaToolsOperationIdFilter.cs
+++ b/Badgernet.Umbraco.MediaTools/Configurations/MediaToolsOperationIdFilter.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Badgernet.Umbraco.MediaTools.Configurations;
+
+internal class MediaToolsOperationIdFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        // Only rewrite OperationId for the "mediatools" group
+        if (!string.Equals(context.ApiDescription.GroupName, "mediatools", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var action = context.ApiDescription.ActionDescriptor.RouteValues.TryGetValue("action", out var name) ? name : null;
+
+        if (!string.IsNullOrWhiteSpace(action))
+            operation.OperationId = action;
+    }
+}


### PR DESCRIPTION
### Issue
After installing the MediaTools the swagger definition of many Umbraco endpoints were also affected. This causes issues in our project as we use codegen tools based on our swagger definition. An example of an affected endpoint:

Before
`"paths": {
    "/umbraco/delivery/api/v2/content": {
      "get": {
        "tags": [
          "Content"
        ],
        "operationId": "GetContent2.0",`

After
`"paths": {
    "/umbraco/delivery/api/v2/content": {
      "get": {
        "tags": [
          "Content"
        ],
        "operationId": "QueryV20",`

### Proposed Solution
Adding a scoped OperationIdFilter, which only applies the custom logic to the MediaTools endpoints